### PR TITLE
Set number of proxies to 1

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ const limiter = rateLimit({
   message: "Too many requests, please try again later.",
 });
 
-app.set("trust proxy", true);
+app.set("trust proxy", 1);
 
 app.use(limiter);
 app.use(morgan("combined"));
@@ -30,6 +30,10 @@ const {
 } = require("./error_handlers/errors");
 
 const apiRouter = require("./routers/api-router");
+
+app.get("/ip", (req, res) => {
+  res.json({ ip: req.ip });
+});
 
 // ROOT
 

--- a/app.js
+++ b/app.js
@@ -11,14 +11,9 @@ const limiter = rateLimit({
   standardHeaders: "draft-7", // combined `RateLimit` header
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   message: "Too many requests, please try again later.",
-  keyGenerator: (req) => {
-    const xForwardedFor = req.headers["x-forwarded-for"];
-    return xForwardedFor ? xForwardedFor.split(",")[0].trim() : req.ip;
-  },
-  validate: { trustProxy: false },
 });
 
-app.set("trust proxy", true);
+app.set("trust proxy", parseInt(process.env.PROXY_HOPS, 10) || 3);
 
 app.use(limiter);
 app.use(morgan("combined"));

--- a/app.js
+++ b/app.js
@@ -11,9 +11,14 @@ const limiter = rateLimit({
   standardHeaders: "draft-7", // combined `RateLimit` header
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   message: "Too many requests, please try again later.",
+  keyGenerator: (req) => {
+    const xForwardedFor = req.headers["x-forwarded-for"];
+    return xForwardedFor ? xForwardedFor.split(",")[0].trim() : req.ip;
+  },
+  validate: { trustProxy: false },
 });
 
-app.set("trust proxy", 3);
+app.set("trust proxy", true);
 
 app.use(limiter);
 app.use(morgan("combined"));

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ const limiter = rateLimit({
   message: "Too many requests, please try again later.",
 });
 
-app.set("trust proxy", 2);
+app.set("trust proxy", 3);
 
 app.use(limiter);
 app.use(morgan("combined"));
@@ -32,6 +32,11 @@ const {
 const apiRouter = require("./routers/api-router");
 
 app.get("/ip", (req, res) => {
+  console.log("--- IP DEBUG START ---");
+  console.log("Standard req.ip:", req.ip);
+  console.log("All IPs (req.ips):", req.ips);
+  console.log("X-Forwarded-For Header:", req.headers["x-forwarded-for"]);
+  console.log("--- IP DEBUG END ---");
   res.json({ ip: req.ip });
 });
 

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ const limiter = rateLimit({
   message: "Too many requests, please try again later.",
 });
 
-app.set("trust proxy", 1);
+app.set("trust proxy", 2);
 
 app.use(limiter);
 app.use(morgan("combined"));

--- a/app.js
+++ b/app.js
@@ -31,15 +31,6 @@ const {
 
 const apiRouter = require("./routers/api-router");
 
-app.get("/ip", (req, res) => {
-  console.log("--- IP DEBUG START ---");
-  console.log("Standard req.ip:", req.ip);
-  console.log("All IPs (req.ips):", req.ips);
-  console.log("X-Forwarded-For Header:", req.headers["x-forwarded-for"]);
-  console.log("--- IP DEBUG END ---");
-  res.json({ ip: req.ip });
-});
-
 // ROOT
 
 app.get("/", getRoot);


### PR DESCRIPTION
This PR fixes:

```
ValidationError: The Express 'trust proxy' setting is true, which allows anyone to trivially bypass IP-based rate limiting. See https://express-rate-limit.github.io/ERR_ERL_PERMISSIVE_TRUST_PROXY/ for more information.
    at Object.trustProxy (/opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:353:13)
    at wrappedValidations.<computed> [as trustProxy] (/opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:685:22)
    at Object.keyGenerator (/opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:787:20)
    at /opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:849:32
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
Menu
    at async /opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:830:5 {
  code: 'ERR_ERL_PERMISSIVE_TRUST_PROXY',
  help: 'https://express-rate-limit.github.io/ERR_ERL_PERMISSIVE_TRUST_PROXY/'
}
```